### PR TITLE
Add a CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [$default-branch]
+  pull_request:
+    branches: [$default-branch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x, 15.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [master]
   pull_request:
-    branches: [$default-branch]
+    branches: [master]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build](https://github.com/lauriharpf/type-graphql-starter/actions/workflows/node.js.yml/badge.svg)
+
 # TypeGraphQL starter template
 
 Starter template for bootstrapping a [TypeGraphQL](https://typegraphql.com/) + [Apollo Server](https://www.apollographql.com/docs/apollo-server/) GraphQL API. The purpose is to help getting started quickly with TypeGraphQL development by providing a runnable API with examples you can build on. Not endorsed by or affiliated with the TypeGraphQL team. Be sure to also check out the [TypeGraphQL documentation](https://typegraphql.com/docs/introduction.html) and [examples](https://typegraphql.com/docs/examples.html).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ query Posts {
 - Test infrastructure ([ts-jest](https://github.com/kulshekhar/ts-jest) and [nock](https://www.npmjs.com/package/nock)) with example tests
 - [ts-node-dev](https://www.npmjs.com/package/ts-node-dev) for development (restarts app when code changes)
 - [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/README.md) with [type-aware rules](https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/TYPED_LINTING.md)
-- Github: Dependabot dependency updates
+- Github: Dependabot dependency updates, Github Actions CI
 
 ## Customizing for your project
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
+  preset: "ts-jest",
+  testEnvironment: "node",
+  rootDir: "src",
 };


### PR DESCRIPTION
- Add a simple Github Actions CI
- Change jest setup so that it doesn't run tests in the build directory (which would lead to running tests twice, both the original TypeScript versions and the compiled JavaScript versions)